### PR TITLE
Delete packages dependecies

### DIFF
--- a/lib/cupper/plugins/cupper/debian.rb
+++ b/lib/cupper/plugins/cupper/debian.rb
@@ -5,8 +5,13 @@ module Cupper
     include PlatformCollector
     def packages(data_extraction)
       packages = Array.new
+      duplicated = Array.new
+      data_extraction['pkg_deps']['pkg_deps'].each do |dep|
+        duplicated << dep[1]
+      end
+      duplicated.flatten!.uniq!
       data_extraction['packages']['packages'].each do |pkg|
-        packages.push(pkg)
+        packages.push(pkg) unless duplicated.include? pkg[0]
       end
       packages
     end

--- a/lib/cupper/plugins/ohai/pkg_deps.rb
+++ b/lib/cupper/plugins/ohai/pkg_deps.rb
@@ -1,0 +1,32 @@
+Ohai.plugin(:PkgDeps) do
+  provides 'pkg_deps'
+  depends 'platform_family'
+
+  def from_cmd(cmd)
+    so = shell_out(cmd)
+    so.stdout.lines
+  end
+
+  def all_packages
+    if %w{debian}.include? platform_family
+      from_cmd("dpkg-query -W")
+    end
+  end
+
+  def extract_dependecies(pkg)
+    pkg_infos = from_cmd("apt-cache showpkg #{pkg}")
+    deps_pos = pkg_infos.index{ |id| id =~ /Dependencies/}
+    pkg_infos[deps_pos+1].split.delete_if { |item|
+      item.match(/(^\(\d)|(^\d*\))|(\(null\))|(^\d*-)|(^\d*~\))|(^\d*:)|(^\d*\.)|(^-)/)
+    }
+  end
+
+  collect_data(:linux) do
+    pkg_deps Mash.new
+    if %w{debian}.include? platform_family
+      all_packages.each do |pkg|
+        pkg_deps[pkg.split.first] = extract_dependecies(pkg.split.first)
+      end
+    end
+  end
+end

--- a/lib/cupper/plugins/ohai/pkg_deps.rb
+++ b/lib/cupper/plugins/ohai/pkg_deps.rb
@@ -15,10 +15,8 @@ Ohai.plugin(:PkgDeps) do
 
   def extract_dependecies(pkg)
     pkg_infos = from_cmd("apt-cache showpkg #{pkg}")
-    deps_pos = pkg_infos.index{ |id| id =~ /Dependencies/}
-    pkg_infos[deps_pos+1].split.delete_if { |item|
-      item.match(/(^\(\d)|(^\d*\))|(\(null\))|(^\d*-)|(^\d*~\))|(^\d*:)|(^\d*\.)|(^-)/)
-    }
+    pkg_infos.keep_if { |item| item.strip!.match(/^Depends:/)}
+    pkg_infos.each { |item| item.slice!("Depends: ") }
   end
 
   collect_data(:linux) do


### PR DESCRIPTION
The extraction of packages was taking all packages. Now the packages that are considered as dependency of another packages are not put on the package recipe. In some point in the future, the user should have the option to remove that by configuration Cupperfile.